### PR TITLE
Simplifying folding API with assumption that return type matches accumulator

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "purescript-either": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^4.0.0"
+    "purescript-psci-support": "^4.0.0",
+    "purescript-assert": "^4.0.0"
   }
 }

--- a/src/Heterogeneous/Folding.purs
+++ b/src/Heterogeneous/Folding.purs
@@ -19,64 +19,64 @@ import Record as Record
 import Type.Data.RowList (RLProxy(..))
 import Type.Proxy (Proxy(..))
 
-class Folding f x y z | f x y -> z where
-  folding :: f -> x -> y -> z
+class Folding f x y where
+  folding :: f -> x -> y -> x
 
-instance functionFolding :: Folding (x -> y -> x) x y x where
+instance functionFolding :: Folding (x -> y -> x) x y where
   folding f = f
 
-class FoldingWithIndex f i x y z | f i x y -> z where
-  foldingWithIndex :: f -> i -> x -> y -> z
+class FoldingWithIndex f i x y where
+  foldingWithIndex :: f -> i -> x -> y -> x
 
-instance functionFoldingWithIndex :: FoldingWithIndex (i -> x -> y -> x) i x y x where
+instance functionFoldingWithIndex :: FoldingWithIndex (i -> x -> y -> x) i x y where
   foldingWithIndex f = f
 
-class HFoldl f x a b | f x a -> b where
-  hfoldl :: f -> x -> a -> b
+class HFoldl f x a where
+  hfoldl :: f -> x -> a -> x
 
-class HFoldlWithIndex f x a b | f x a -> b where
-  hfoldlWithIndex :: f -> x -> a -> b
+class HFoldlWithIndex f x a where
+  hfoldlWithIndex :: f -> x -> a -> x
 
 newtype ConstFolding f = ConstFolding f
 
 instance constFolding ::
-  ( Folding f x y z
+  ( Folding f x y
   ) =>
-  FoldingWithIndex (ConstFolding f) i x y z
+  FoldingWithIndex (ConstFolding f) i x y
   where
   foldingWithIndex (ConstFolding f) _ = folding f
 
 instance hfoldlApp ::
   ( Foldable g
-  , Folding f x y x
+  , Folding f x y
   ) =>
-  HFoldl f x (App g y) x
+  HFoldl f x (App g y)
   where
   hfoldl f x (App g) =
     foldl (folding f) x g
 
 instance hfoldlWithIndexApp ::
   ( FoldableWithIndex i g
-  , FoldingWithIndex f i x y x
+  , FoldingWithIndex f i x y
   ) =>
-  HFoldlWithIndex f x (App g y) x
+  HFoldlWithIndex f x (App g y)
   where
   hfoldlWithIndex f x (App g) =
     foldlWithIndex (foldingWithIndex f) x g
 
 instance hfoldlRowList ::
-  ( HFoldlWithIndex (ConstFolding f) x (RLProxy rl) b
+  ( HFoldlWithIndex (ConstFolding f) x (RLProxy rl)
   ) =>
-  HFoldl f x (RLProxy rl) b
+  HFoldl f x (RLProxy rl)
   where
   hfoldl f =
     hfoldlWithIndex (ConstFolding f)
 
 instance hfoldlWithIndexRowListCons ::
-  ( FoldingWithIndex f (SProxy sym) x (Proxy y) z
-  , HFoldlWithIndex f z (RLProxy rl) b
+  ( FoldingWithIndex f (SProxy sym) x (Proxy y)
+  , HFoldlWithIndex f x (RLProxy rl)
   ) =>
-  HFoldlWithIndex f x (RLProxy (RL.Cons sym y rl)) b
+  HFoldlWithIndex f x (RLProxy (RL.Cons sym y rl))
   where
   hfoldlWithIndex f x _ =
     hfoldlWithIndex f
@@ -84,38 +84,38 @@ instance hfoldlWithIndexRowListCons ::
       (RLProxy :: RLProxy rl)
 
 instance hfoldlWithIndexRowListNil ::
-  HFoldlWithIndex f x (RLProxy RL.Nil) x
+  HFoldlWithIndex f x (RLProxy RL.Nil)
   where
   hfoldlWithIndex f x _ = x
 
 instance hfoldlRecord ::
   ( RL.RowToList r rl
-  , FoldlRecord (ConstFolding f) x rl r b
+  , FoldlRecord (ConstFolding f) x rl r
   ) =>
-  HFoldl f x { | r } b
+  HFoldl f x { | r }
   where
   hfoldl f x =
     foldlRecordRowList (ConstFolding f) x (RLProxy :: RLProxy rl)
 
 instance hfoldlRecordWithIndex ::
   ( RL.RowToList r rl
-  , FoldlRecord f x rl r b
+  , FoldlRecord f x rl r
   ) =>
-  HFoldlWithIndex f x { | r } b
+  HFoldlWithIndex f x { | r }
   where
   hfoldlWithIndex f x =
     foldlRecordRowList f x (RLProxy :: RLProxy rl)
 
-class FoldlRecord f x (rl :: RowList) (r :: # Type) b | f x rl -> b, rl -> r where
-  foldlRecordRowList :: f -> x -> RLProxy rl -> { | r } -> b
+class FoldlRecord f x (rl :: RowList) (r :: # Type) | rl -> r where
+  foldlRecordRowList :: f -> x -> RLProxy rl -> { | r } -> x
 
 instance foldlRecordCons ::
   ( IsSymbol sym
   , Row.Cons sym a r' r
-  , FoldingWithIndex f (SProxy sym) x a z
-  , FoldlRecord f z rl r b
+  , FoldingWithIndex f (SProxy sym) x a
+  , FoldlRecord f x rl r
   ) =>
-  FoldlRecord f x (RL.Cons sym a rl) r b
+  FoldlRecord f x (RL.Cons sym a rl) r
   where
   foldlRecordRowList f x _ r =
     foldlRecordRowList f
@@ -125,24 +125,24 @@ instance foldlRecordCons ::
     prop = SProxy :: SProxy sym
 
 instance foldlRecordNil ::
-  FoldlRecord f x RL.Nil r x
+  FoldlRecord f x RL.Nil r
   where
   foldlRecordRowList _ x _ _ = x
 
 instance hfoldlTuple ::
-  ( Folding f x a y
-  , Folding f y b z
+  ( Folding f x a
+  , Folding f x b
   ) =>
-  HFoldl f x (Tuple a b) z
+  HFoldl f x (Tuple a b)
   where
   hfoldl f x (Tuple a b) =
     folding f (folding f x a) b
 
 instance hfoldlEither ::
-  ( Folding f x a y
-  , Folding f x b y
+  ( Folding f x a
+  , Folding f x b
   ) =>
-  HFoldl f x (Either a b) y
+  HFoldl f x (Either a b)
   where
   hfoldl f x = case _ of
     Left a -> folding f x a
@@ -150,32 +150,32 @@ instance hfoldlEither ::
 
 instance hfoldlVariant ::
   ( RL.RowToList r rl
-  , FoldlVariant (ConstFolding f) x rl r y
+  , FoldlVariant (ConstFolding f) x rl r
   ) =>
-  HFoldl f x (Variant r) y
+  HFoldl f x (Variant r)
   where
   hfoldl =
     foldlVariantRowList (RLProxy :: RLProxy rl) <<< ConstFolding
 
 instance hfoldlVariantWithIndex ::
   ( RL.RowToList r rl
-  , FoldlVariant f x rl r y
+  , FoldlVariant f x rl r
   ) =>
-  HFoldlWithIndex f x (Variant r) y
+  HFoldlWithIndex f x (Variant r)
   where
   hfoldlWithIndex =
     foldlVariantRowList (RLProxy :: RLProxy rl)
 
-class FoldlVariant f x (rl :: RowList) (r :: # Type) b | f x rl -> b, rl -> r where
-  foldlVariantRowList :: RLProxy rl -> f -> x -> Variant r -> b
+class FoldlVariant f x (rl :: RowList) (r :: # Type) | rl -> r where
+  foldlVariantRowList :: RLProxy rl -> f -> x -> Variant r -> x
 
 instance foldlVariantCons ::
   ( IsSymbol sym
   , Row.Cons sym a r1 r2
-  , FoldingWithIndex f (SProxy sym) x a y
-  , FoldlVariant f x rest r1 y
+  , FoldingWithIndex f (SProxy sym) x a
+  , FoldlVariant f x rest r1
   ) =>
-  FoldlVariant f x (RL.Cons sym a rest) r2 y
+  FoldlVariant f x (RL.Cons sym a rest) r2
   where
   foldlVariantRowList _ f x =
     foldlVariantRowList (RLProxy :: RLProxy rest) f x
@@ -183,37 +183,37 @@ instance foldlVariantCons ::
     where
     label = SProxy :: SProxy sym
 
-instance foldlVariantNil :: FoldlVariant f x RL.Nil () y where
+instance foldlVariantNil :: FoldlVariant f x RL.Nil () where
   foldlVariantRowList _ _ _ = Variant.case_
 
 instance hfoldlVariantF ::
   ( RL.RowToList r rl
-  , FoldlVariantF (ConstFolding f) x rl r z y
+  , FoldlVariantF (ConstFolding f) x rl r z
   ) =>
-  HFoldl f x (VariantF r z) y
+  HFoldl f x (VariantF r z)
   where
   hfoldl =
     foldlVariantFRowList (RLProxy :: RLProxy rl) <<< ConstFolding
 
 instance hfoldlVariantFWithIndex ::
   ( RL.RowToList r rl
-  , FoldlVariantF f x rl r z y
+  , FoldlVariantF f x rl r z
   ) =>
-  HFoldlWithIndex f x (VariantF r z) y
+  HFoldlWithIndex f x (VariantF r z)
   where
   hfoldlWithIndex =
     foldlVariantFRowList (RLProxy :: RLProxy rl)
 
-class FoldlVariantF f x (rl :: RowList) (r :: # Type) z y | f x rl z -> r y where
-  foldlVariantFRowList :: RLProxy rl -> f -> x -> VariantF r z -> y
+class FoldlVariantF f x (rl :: RowList) (r :: # Type) z | f x rl z -> r where
+  foldlVariantFRowList :: RLProxy rl -> f -> x -> VariantF r z -> x
 
 instance foldlVariantFCons ::
   ( IsSymbol sym
   , Row.Cons sym (FProxy a) r1 r2
-  , FoldingWithIndex f (SProxy sym) x (a z) y
-  , FoldlVariantF f x rest r1 z y
+  , FoldingWithIndex f (SProxy sym) x (a z)
+  , FoldlVariantF f x rest r1 z
   ) =>
-  FoldlVariantF f x (RL.Cons sym (FProxy a) rest) r2 z y
+  FoldlVariantF f x (RL.Cons sym (FProxy a) rest) r2 z
   where
   foldlVariantFRowList _ f x =
     foldlVariantFRowList (RLProxy :: RLProxy rest) f x
@@ -221,5 +221,5 @@ instance foldlVariantFCons ::
     where
     label = SProxy :: SProxy sym
 
-instance foldlVariantFNil :: FoldlVariantF f x RL.Nil () z y where
+instance foldlVariantFNil :: FoldlVariantF f x RL.Nil () z where
   foldlVariantFRowList _ _ _ = VariantF.case_

--- a/src/Heterogeneous/Folding.purs
+++ b/src/Heterogeneous/Folding.purs
@@ -127,7 +127,7 @@ instance foldlRecordCons ::
 instance foldlRecordNil ::
   FoldlRecord f x RL.Nil r x
   where
-  foldlRecordRowList f x _ r = x
+  foldlRecordRowList _ x _ _ = x
 
 instance hfoldlTuple ::
   ( Folding f x a y

--- a/test/HList.purs
+++ b/test/HList.purs
@@ -3,7 +3,9 @@ module Test.HList where
 import Prelude
 
 import Data.Tuple (Tuple(..))
+import Effect (Effect)
 import Heterogeneous.Folding (class Folding, class FoldingWithIndex, class HFoldl, class HFoldlWithIndex, folding, foldingWithIndex, hfoldl, hfoldlWithIndex)
+import Test.Assert (assertEqual')
 
 foreign import kind Peano
 foreign import data S :: Peano -> Peano
@@ -91,9 +93,15 @@ showWithIndex :: forall hlist.
 showWithIndex =
   hfoldlWithIndex ShowWithIndex ([] :: Array (Tuple Int String))
 
-testShow :: _
-testShow =
-  showWithIndex ("foo" : 42 : true : 12.0 : HNil)
+testShowWithIndex :: Effect Unit
+testShowWithIndex =
+  assertEqual'
+    "testShowWithIndex"
+    { actual:
+        showWithIndex ("foo" : 42 : true : 12.0 : HNil)
+    , expected:
+        [(Tuple 0 "\"foo\""),(Tuple 1 "42"),(Tuple 2 "true"),(Tuple 3 "12.0")]
+    }
 
 data ShowHList = ShowHList
 
@@ -108,6 +116,17 @@ showHList :: forall hlist.
 showHList h =
   "(" <> hfoldl ShowHList "" h <> " : HNil)"
 
-testShow2 :: _
-testShow2 =
-  showHList ("foo" : 42 : true : 12.0 : HNil)
+testShowHList :: Effect Unit
+testShowHList =
+  assertEqual'
+    "testShowHList"
+    { actual:
+        showHList ("foo" : 42 : true : 12.0 : HNil)
+    , expected:
+        "(\"foo\" : 42 : true : 12.0 : HNil)"
+    }
+
+runHListTests :: Effect Unit
+runHListTests = do
+  testShowWithIndex
+  testShowHList

--- a/test/HList.purs
+++ b/test/HList.purs
@@ -30,49 +30,49 @@ infixr 8 HCons as :
 
 newtype Counting (p :: Peano) a = Counting a
 
-instance hfoldlWithIndexCounting_nil :: HFoldlWithIndex f x (Counting p HNil) x where
+instance hfoldlWithIndexCounting_nil :: HFoldlWithIndex f x (Counting p HNil) where
   hfoldlWithIndex _ x _ = x
 
 instance hfoldlWithIndexCounting_go ::
-  ( FoldingWithIndex f (Peano p) x a y
-  , HFoldlWithIndex f y (Counting (S p) b) z
+  ( FoldingWithIndex f (Peano p) x a
+  , HFoldlWithIndex f x (Counting (S p) b)
   ) =>
-  HFoldlWithIndex f x (Counting p (HCons a b)) z
+  HFoldlWithIndex f x (Counting p (HCons a b))
   where
   hfoldlWithIndex f x (Counting (HCons a b)) = z
     where
     y = foldingWithIndex f (Peano :: Peano p) x a
     z = hfoldlWithIndex f y (Counting b :: Counting (S p) b)
 
-instance hfoldlWithIndexHNil :: HFoldlWithIndex f x HNil x where
+instance hfoldlWithIndexHNil :: HFoldlWithIndex f x HNil where
   hfoldlWithIndex _ x _ = x
 
 instance hfoldlWithIndexHCons ::
-  ( FoldingWithIndex f (Peano Z) x a y
-  , HFoldlWithIndex f y (Counting (S Z) rest) z
+  ( FoldingWithIndex f (Peano Z) x a
+  , HFoldlWithIndex f x (Counting (S Z) rest)
   ) =>
-  HFoldlWithIndex f x (HCons a rest) z
+  HFoldlWithIndex f x (HCons a rest)
   where
   hfoldlWithIndex f x (HCons a rest) = z
     where
     y = foldingWithIndex f (Peano :: Peano Z) x a
     z = hfoldlWithIndex f y (Counting rest :: Counting (S Z) rest)
 
-instance hfoldlHNil :: HFoldl f x HNil x where
+instance hfoldlHNil :: HFoldl f x HNil where
   hfoldl _ x _ = x
 else
 instance hfoldlHCons_one ::
-  Folding f x a z =>
-  HFoldl f x (HCons a HNil) z
+  Folding f x a =>
+  HFoldl f x (HCons a HNil)
   where
   hfoldl f x (HCons a _) =
     folding f x a
 else
 instance hfoldlHCons_many ::
-  ( Folding f x a y
-  , HFoldl f y (HCons b c) z
+  ( Folding f x a
+  , HFoldl f x (HCons b c)
   ) =>
-  HFoldl f x (HCons a (HCons b c)) z
+  HFoldl f x (HCons a (HCons b c))
   where
   hfoldl f x (HCons a rest) =
     hfoldl f (folding f x a) rest
@@ -81,13 +81,13 @@ data ShowWithIndex = ShowWithIndex
 
 instance foldingShowWithIndex ::
   (KnownPeano p, Show a) =>
-  FoldingWithIndex ShowWithIndex (Peano p) (Array (Tuple Int String)) a (Array (Tuple Int String))
+  FoldingWithIndex ShowWithIndex (Peano p) (Array (Tuple Int String)) a
   where
   foldingWithIndex _ p as a =
     as <> [ Tuple (reflectPeano p) (show a) ]
 
 showWithIndex :: forall hlist.
-  HFoldlWithIndex ShowWithIndex (Array (Tuple Int String)) hlist (Array (Tuple Int String)) =>
+  HFoldlWithIndex ShowWithIndex (Array (Tuple Int String)) hlist =>
   hlist ->
   Array (Tuple Int String)
 showWithIndex =
@@ -105,12 +105,12 @@ testShowWithIndex =
 
 data ShowHList = ShowHList
 
-instance foldingShowHList :: Show a => Folding ShowHList String a String where
+instance foldingShowHList :: Show a => Folding ShowHList String a where
   folding _ "" a = show a
   folding _ bs a = bs <> " : " <> show a
 
 showHList :: forall hlist.
-  HFoldl ShowHList String hlist String =>
+  HFoldl ShowHList String hlist =>
   hlist ->
   String
 showHList h =

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,10 +3,8 @@ module Test.Main where
 import Prelude
 
 import Effect (Effect)
-import Effect.Console (log)
-import Test.Assert (assert)
+import Test.Record (runRecordTests)
 
 main :: Effect Unit
 main = do
-  log "Testing"
-  assert true
+  runRecordTests

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,7 +4,9 @@ import Prelude
 
 import Effect (Effect)
 import Test.Record (runRecordTests)
+import Test.Variant (runVariantTests)
 
 main :: Effect Unit
 main = do
   runRecordTests
+  runVariantTests

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -5,8 +5,10 @@ import Prelude
 import Effect (Effect)
 import Test.Record (runRecordTests)
 import Test.Variant (runVariantTests)
+import Test.HList (runHListTests)
 
 main :: Effect Unit
 main = do
   runRecordTests
   runVariantTests
+  runHListTests

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,12 @@
+module Test.Main where
+
+import Prelude
+
+import Effect (Effect)
+import Effect.Console (log)
+import Test.Assert (assert)
+
+main :: Effect Unit
+main = do
+  log "Testing"
+  assert true

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -4,7 +4,9 @@ import Prelude
 
 import Data.Variant (SProxy(..), Variant)
 import Data.Variant as Variant
+import Effect (Effect)
 import Heterogeneous.Folding (class Folding, class HFoldl, hfoldl)
+import Test.Assert (assertEqual')
 
 data ShowCase = ShowCase
 
@@ -29,6 +31,16 @@ showVariantValue :: forall r.
 showVariantValue =
   hfoldl ShowCase ""
 
-test :: String
-test =
-  showVariantValue someFoo
+testShowVariantValue :: Effect Unit
+testShowVariantValue =
+  assertEqual'
+    "testShowVariantValue"
+    { actual:
+        showVariantValue someFoo
+    , expected:
+        "42"
+    }
+
+runVariantTests :: Effect Unit
+runVariantTests = do
+  testShowVariantValue

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -12,7 +12,7 @@ data ShowCase = ShowCase
 
 instance showCase ::
   Show a =>
-  Folding ShowCase String a String where
+  Folding ShowCase String a where
   folding ShowCase s = append s <<< show
 
 type TestLabels =
@@ -25,7 +25,7 @@ someFoo :: Variant TestLabels
 someFoo = Variant.inj (SProxy :: SProxy "foo") 42
 
 showVariantValue :: forall r.
-  HFoldl ShowCase String (Variant r) String =>
+  HFoldl ShowCase String (Variant r) =>
   Variant r ->
   String
 showVariantValue =


### PR DESCRIPTION
It seems that the return type of all folds should match the accumulator.
This makes the API a bit simpler.

This PR is based on #7, and there are no test regressions, with the following caveats:
* I haven't figured out how to update the `Record.Builder` tests. I'll spend some more time on this tomorrow, but let me know if you see the obvious fix, or if this is incompatible with the new API.
* `showPropsCase` was previously relying on `Unit` accumulator input as a special initial value to skip the first separator. I think the new version is clearer though, and more closely matches how the tutorial solves this problem. It might also be worth looking into how to leverage `intercalate`.