### PR TITLE
Remove unused names

### DIFF
--- a/src/Heterogeneous/Folding.purs
+++ b/src/Heterogeneous/Folding.purs
@@ -85,7 +85,7 @@ instance hfoldlWithIndexRowListCons ::
 instance hfoldlWithIndexRowListNil ::
   HFoldlWithIndex f x (Proxy RL.Nil) x
   where
-  hfoldlWithIndex f x _ = x
+  hfoldlWithIndex _ x _ = x
 
 instance hfoldlRecord ::
   ( RL.RowToList r rl
@@ -126,7 +126,7 @@ instance foldlRecordCons ::
 instance foldlRecordNil ::
   FoldlRecord f x RL.Nil r x
   where
-  foldlRecordRowList f x _ r = x
+  foldlRecordRowList _ x _ _ = x
 
 instance hfoldlTuple ::
   ( Folding f x a y

--- a/test/Record.purs
+++ b/test/Record.purs
@@ -13,7 +13,7 @@ import Prim.Row as Row
 import Record as Record
 import Record.Builder (Builder)
 import Record.Builder as Builder
-import Type.Proxy (Proxy(..))
+import Type.Proxy (Proxy)
 
 newtype ZipProp r = ZipProp { | r }
 
@@ -298,7 +298,7 @@ instance showValues ::
   (Show a, IsSymbol sym) =>
   FoldingWithIndex ShowValues (Proxy sym) String a String
   where
-  foldingWithIndex _ prop str a = pre <> show a
+  foldingWithIndex _ _ str a = pre <> show a
     where
     pre | str == "" = ""
         | otherwise = str <> ", "

--- a/test/Variant.purs
+++ b/test/Variant.purs
@@ -2,9 +2,10 @@ module Test.Variant where
 
 import Prelude
 
-import Data.Variant (SProxy(..), Variant)
+import Data.Variant (Variant)
 import Data.Variant as Variant
 import Heterogeneous.Folding (class Folding, class HFoldl, hfoldl)
+import Type.Proxy (Proxy(..))
 
 data ShowCase = ShowCase
 
@@ -20,7 +21,7 @@ type TestLabels =
   )
 
 someFoo :: Variant TestLabels
-someFoo = Variant.inj (SProxy :: SProxy "foo") 42
+someFoo = Variant.inj (Proxy :: Proxy "foo") 42
 
 showVariantValue :: forall r.
   HFoldl ShowCase String (Variant r) String =>


### PR DESCRIPTION
Removes unused names, as they now warn on PureScript 0.14.1. Also fixes some imports in test code.